### PR TITLE
rework: management controller collection

### DIFF
--- a/packethardware/component/management_controller.py
+++ b/packethardware/component/management_controller.py
@@ -8,11 +8,27 @@ class ManagementController(Component):
 
         self.data = {}
 
-        self.model = utils.dmidecode_string("system-product-name")
-        self.name = self.model + " Base Management Controller"
+        self.model = utils.get_fru_info("Board Part Number")
+        self.name = utils.dmidecode_string("system-product-name")
+
         self.vendor = utils.normalize_vendor(utils.get_mc_info("vendor"))
+
+        if self.vendor == "Dell Inc.":
+            try:
+                self.firmware_version = utils.get_dell_management_fw_version("firmware_version")
+            except:
+                utils.log(message="Something went wrong, probably no racadm.")
+                self.firmware_version = ""
+        elif self.vendor == "Supermicro":
+            try:
+                self.firmware_version = utils.get_smc_management_fw_version("firmware_version")
+            except:
+                utils.log(message="Something went wrong, probably no ipmicfg.")
+                self.firmware_version = ""
+        else:
+            self.firmware_version = ""
+
         self.serial = utils.get_mc_info("guid")
-        self.firmware_version = utils.get_mc_info("firmware_version")
 
     @classmethod
     def list(cls, _):

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -489,3 +489,29 @@ def get_smc_baseboard_cpld(prop):
     cpld_version = cmd_output("ipmicfg", "-summary")
 
     return __re_multiline_first(cpld_version, regex[prop]).strip()
+
+
+def get_dell_management_fw_version(prop):
+    regex = {
+        "firmware_version": re.compile(r"^Firmware Version\s+=\s+(.*)$", re.MULTILINE),
+    }
+
+    if prop not in regex:
+        return ""
+
+    racadm_mc_version = cmd_output("/opt/dell/srvadmin/bin/idracadm7", "getsysinfo")
+
+    return __re_multiline_first(racadm_mc_version, regex[prop]).strip()
+
+
+def get_smc_management_fw_version(prop):
+    regex = {
+        "firmware_version": re.compile(r"^Firmware Revision\s+:\s+(.*)$", re.MULTILINE),
+    }
+
+    if prop not in regex:
+        return ""
+
+    ipmicfg_mc_version = cmd_output("ipmicfg", "-summary")
+
+    return __re_multiline_first(ipmicfg_mc_version, regex[prop]).strip()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="packet-hardware",
-    version="1.1",
+    version="1.2",
     description="Tool used to discover hardware components and update packet's api",
     author="James W. Brinkerhoff",
     author_email="jwb@packet.com",


### PR DESCRIPTION
When identifying model, dmidecode returns vague or unreliable 
information from the system-product-name flag. Now that we have access 
to ipmicfg and racadm we can get better results so we'll need to use 
this.