### PR TITLE
bmc: improve vague supermicro model names

### DIFF
--- a/packethardware/component/management_controller.py
+++ b/packethardware/component/management_controller.py
@@ -6,13 +6,32 @@ class ManagementController(Component):
     def __init__(self):
         Component.__init__(self)
 
-        self.data = {}
 
         self.model = utils.dmidecode_string("system-product-name")
-        self.name = self.model + " Base Management Controller"
+        self.firmware_version = utils.get_mc_info("firmware_version")
+
+        if self.model == "Super Server":
+            try:
+                self.model = utils.get_fru_info("Board Part Number")
+                self.name = utils.dmidecode_string("system-product-name")
+            except:
+                utils.log(message="Something went wrong, probably no ipmitool.")
+                self.firmware_version = ""
+        elif self.model == "AS -1114S-WTRT":
+            try:
+                self.model = utils.get_fru_info("Board Part Number")
+                self.name = utils.dmidecode_string("system-product-name")
+                self.firmware_version = utils.get_mc_info("firmware_version")
+            except:
+                utils.log(message="Something went wrong, probably no ipmitool.")
+                self.firmware_version = ""
+        else:
+            self.name = self.model + " Base Management Controller"
+
         self.vendor = utils.normalize_vendor(utils.get_mc_info("vendor"))
         self.serial = utils.get_mc_info("guid")
-        self.firmware_version = utils.get_mc_info("firmware_version")
+
+        self.data = {}
 
     @classmethod
     def list(cls, _):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="packet-hardware",
-    version="1.1",
+    version="1.2",
     description="Tool used to discover hardware components and update packet's api",
     author="James W. Brinkerhoff",
     author_email="jwb@packet.com",


### PR DESCRIPTION
It seems that for some Supermicro boards dmidecode reports vague or 
unhelpful models. Lets normalize those into something useful by 
collecting with ipmitool's fru flag instead.