### PR TITLE
Add the ability to write bios inventory json to hollow service

### DIFF
--- a/packethardware/inventorybios.py
+++ b/packethardware/inventorybios.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import click
+import json
 
 from . import utils
 
 
 @click.command()
-@click.option("--tinkerbell", "-u", help="Tinkerbell uri", required=True)
+@click.option("--uuid", help="Hardware UUID of server", required=True)
+@click.option("--hollow", "-u", help="Hollow uri", required=True)
 @click.option(
     "--verbose",
     "-v",
@@ -18,23 +20,37 @@ from . import utils
     "--dry",
     "-d",
     default=False,
-    help="Don't actually post anything to the database",
+    help="Don't actually post anything to Hollow",
     is_flag=True,
 )
 @click.option(
     "--cache-file",
     "-c",
-    default="/tmp/components.jsonpickle",
-    help="Path to local json component store",
+    default="/tmp/inventorybios.json",
+    help="Path to local json bios features store",
 )
-def inventorybios(tinkerbell, verbose, dry, cache_file):
+def inventorybios(hollow, uuid, verbose, dry, cache_file):
     bios_features = utils.get_bios_features()
 
     if verbose:
         utils.log(name="biosfeatures", contents=bios_features)
 
+    # Inject the hwuuid into the json
+    bios_features_final = {"hardware_uuid": uuid, "values": bios_features}
+
     with open(cache_file, "w") as output:
-        output.write(bios_features)
+        output.write(json.dumps(bios_features_final))
 
     if not dry:
-        print("Writing to the database is not yet implemented")
+        response = utils.http_request(hollow, json.dumps(bios_features_final), "POST")
+
+        if response:
+            utils.log(
+                info="Posted BIOS feature inventory to Hollow", body=response.read()
+            )
+            return True
+        return False
+
+
+if __name__ == "__main__":
+    inventorybios(auto_envvar_prefix="BIOS")


### PR DESCRIPTION
Hollow is a service that will store hardware-related info, such as
firmware and bios versions, and the bios feature inventory. This enables
writing to that service via HTTP if the '--dry' option is left off from
the 'inventorybios' command.

Signed-off-by: Scott Garman <sgarman@equinix.com>