### PR TITLE
feat: add Dell BOSS disk support

### DIFF
--- a/packethardware/component/disk.py
+++ b/packethardware/component/disk.py
@@ -54,6 +54,9 @@ class Disk(Component):
         else:
             self.vendor = utils.normalize_vendor(self.vendor)
 
+    def __is_boss(self):
+        return self.lsblk["model"].startswith("DELLBOSS")
+
     def __is_nvme(self):
         return self.lsblk["name"].startswith("/dev/nvme")
 

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -206,6 +206,21 @@ def get_hdparm_diskprop(device, prop):
     return __re_multiline_first(hdparm_data, regex[prop]).strip()
 
 
+def get_dellboss_diskprop(prop):
+    regex = {
+        "name": re.compile(r"^   ProductId +=+(.*)$", re.MULTILINE),
+        "vendor": re.compile(r"^   Manufacturer +=+(.*)$", re.MULTILINE),
+        "model": re.compile(r"^   PartNumber +=+(.*)$", re.MULTILINE),
+        "serial": re.compile(r"^   SerialNumber +=+(.*)$", re.MULTILINE),
+        "firmware_version": re.compile(r"^   Revision +=+(.*)$", re.MULTILINE),
+    }
+
+    if prop not in regex:
+        return ""
+
+    return __re_multiline_first(pdisk_output, regex[prop]).strip()
+
+
 def __re_multiline_first(data, regex_c):
     m = regex_c.search(data)
 

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -221,6 +221,16 @@ def get_dellboss_diskprop(prop):
     return __re_multiline_first(pdisk_output, regex[prop]).strip()
 
 
+def get_boss_devices():
+    boss_data = cmd_output("racadm", "storage", "get", "pdisks")
+
+    boss_map = {}
+
+    disks = []
+
+    return smart_map
+
+
 def __re_multiline_first(data, regex_c):
     m = regex_c.search(data)
 

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -278,6 +278,7 @@ def get_dellboss_diskprop(prop, pdisk_output):
 
     return __re_multiline_first(pdisk_output, regex[prop]).strip()
 
+
 def get_boss_devices():
     disks_data = cmd_output("racadm", "storage", "get", "pdisks")
 
@@ -299,6 +300,7 @@ def get_boss_devices():
         disks.append(disk_info)
 
     return disks
+
 
 def __re_multiline_first(data, regex_c):
     m = regex_c.search(data)


### PR DESCRIPTION
Lets show the individual disks instead of the array

```
racadm storage get pdisks
Disk.Direct.0-0:AHCI.Slot.1-1
Disk.Direct.1-1:AHCI.Slot.1-1
```

```
$ racadm storage get pdisks:Disk.Direct.0-0:AHCI.Slot.1-1
    Disk.Direct.0-0:AHCI.Slot.1-1
       Status                           = Ok
       DeviceDescription                = Disk 0 on AHCI Controller in slot 1
       RollupStatus                     = Ok
       Name                             = SSD 0
       State                            = Online
       OperationState                   = Not Applicable
       PowerStatus                      = On
       Size                             = 223.571 GB
       FailurePredicted                 = NO
       RemainingRatedWriteEndurance     = 100 %
       SecurityStatus                   = Not Capable
       BusProtocol                      = SATA
       MediaType                        = SSD
       UsedRaidDiskSpace                = 223.509 GB
       AvailableRaidDiskSpace           = 0.001 GB
       Hotspare                         = NO
       Manufacturer                     = INTEL
       ProductId                        = SSDSCKKB240G8R
       Revision                         = XC31DL6P
       SerialNumber                     = PHYH951604K8240J
       PartNumber                       = WTD0CM51IPIH0T1140CS0A
```