### PR TITLE
Use aux version bytes to enhance reported openbmc version

### DIFF
--- a/packethardware/component/management_controller.py
+++ b/packethardware/component/management_controller.py
@@ -30,7 +30,7 @@ class ManagementController(Component):
         self.vendor = utils.normalize_vendor(utils.get_mc_info("vendor"))
         self.serial = utils.get_mc_info("guid")
 
-        self.data = {}
+        self.data = {"aux": utils.get_mc_info("aux")}
 
     @classmethod
     def list(cls, _):

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -346,7 +346,7 @@ def get_dmidecode_prop(handle, dmi_type, prop):
     r = re.compile(
         r"^Handle (\S+), DMI type 17, 40 bytes\nMemory Device((?:\n.+)+)", re.MULTILINE
     )
-    for (dmi_handle, body) in re.findall(r, dmi_data):
+    for dmi_handle, body in re.findall(r, dmi_data):
         if handle != dmi_handle:
             continue
 
@@ -458,9 +458,9 @@ def get_mc_info(prop):
         "firmware_version": re.compile(r"^Firmware Revision\s+:\s+(.*)$", re.MULTILINE),
         "guid": re.compile(r"^System GUID\s+:\s+(.*)$", re.MULTILINE),
         "aux": re.compile(
-            r"^Aux Firmware Rev Info\s+:\s+(0x.*\s+0x.*\s+0x.*\s+0x.*)$",
-            re.MULTILINE),
-     }
+            r"^Aux Firmware Rev Info\s+:\s+(0x.*\s+0x.*\s+0x.*\s+0x.*)$", re.MULTILINE
+        ),
+    }
 
     if prop not in regex:
         return ""
@@ -469,13 +469,15 @@ def get_mc_info(prop):
         "ipmitool", "mc", "info"
     )
 
-    if prop == 'aux':
-        return re.sub(
-            r"\s+", ' ', __re_multiline_first(mc_info, regex[prop]).strip())
-    elif prop == 'firmware_version':
+    if prop == "aux":
+        return re.sub(r"\s+", " ", __re_multiline_first(mc_info, regex[prop]).strip())
+    elif prop == "firmware_version":
         # Note that aux byte 0 is patch version in BCD, so 0x11 mean X.Y.11
-        return __re_multiline_first(mc_info, regex[prop]).strip() + '.' \
-            + get_mc_info('aux')[2:4]
+        return (
+            __re_multiline_first(mc_info, regex[prop]).strip()
+            + "."
+            + get_mc_info("aux")[2:4]
+        )
     else:
         return __re_multiline_first(mc_info, regex[prop]).strip()
 


### PR DESCRIPTION
Current version is reported as `X.Y`.

However, our stable versions of openbmc follow the format `X.Y.Z` and for testing version `X.Y.Z-N-g[git revision]`.

This branch adds the ability to take this information from "aux version" bytes which are additional (currently unused) bytes that are reserved for this purpose.