### PR TITLE
In memory.py, we're calculating GB's slightly incorrectly, instead of…

### DIFF
--- a/packethardware/component/memory.py
+++ b/packethardware/component/memory.py
@@ -23,7 +23,8 @@ class Memory(Component):
 
         self.data = {
             "slot": utils.xml_ev(lshw, element, "slot"),
-            "size": str(int(int(utils.xml_ev(lshw, element, "size")) / 1024000000))
+            # "size" is reported in bytes, so divide by 1024^3 to get an accurate human-readable number
+            "size": str(int(int(utils.xml_ev(lshw, element, "size")) / 1073741824))
             + "GB",
             "clock": int(utils.xml_ev(lshw, element, "clock")) / 1000000
             if utils.xml_ev(lshw, element, "clock")

--- a/packethardware/component/memory.py
+++ b/packethardware/component/memory.py
@@ -23,7 +23,8 @@ class Memory(Component):
 
         self.data = {
             "slot": utils.xml_ev(lshw, element, "slot"),
-            # "size" is reported in bytes, so divide by 1024^3 to get an accurate human-readable number
+            # "size" is reported in bytes, so divide by 1024^3 to get an accurate
+            # human-readable number
             "size": str(int(int(utils.xml_ev(lshw, element, "size")) / 1073741824))
             + "GB",
             "clock": int(utils.xml_ev(lshw, element, "clock")) / 1000000


### PR DESCRIPTION
… dividing # of bytes by 1,024,000,000, we should be dividing by 1024^3.

Right now on a server with 2 32GB DIMMs (https://staff.equinixmetal.net/hardware/ff5814d0-99e3-414a-b810-09086678651e/components), we're actually reporting the size of each DIMM as 33GB due to the division here being slightly off:
![Screenshot 2023-07-12 at 12 20 04 PM](https://github.com/packethost/packet-hardware/assets/545037/0fdc1547-d72b-44f8-afcf-491e6ac27b01)


I don't think this error is really actually hurting anything, but might be nice to report more-correct numbers here.
