### PR TITLE
output raw byte size when gathering drive sizes via lsblk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN curl -sL "${SMARTMONTOOLS_BASEURL}/${SMARTMONTOOLS_RELEASE}/${SMARTMONTOOLS_
 # Install racadm
 RUN apt-get update && apt-get install -y alien && \
     rpm --import http://linux.dell.com/repo/pgp_pubkeys/0x1285491434D8786F.asc && \
-    wget \
+    wget -U "Mozilla" \
       https://dl.dell.com/FOLDER05920767M/1/DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz \
       http://linux.dell.com/repo/community/openmanage/940/bionic/pool/main/s/srvadmin-omilcore/srvadmin-omilcore_9.4.0_amd64.deb && \
     tar -xvf DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz && \

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -87,7 +87,7 @@ def ethtool_mac(interface_name):
 
 def lsblk():
     lsblk_json = cmd_output(
-        "lsblk", "-J", "-p", "-o", "NAME,SERIAL,MODEL,SIZE,REV,VENDOR"
+        "lsblk", "-b", "-J", "-p", "-o", "NAME,SERIAL,MODEL,SIZE,REV,VENDOR"
     )
     return json.loads(lsblk_json)["blockdevices"]
 


### PR DESCRIPTION
by default, `lsblk` outputs drive sizes in "human-readable" form, using "gibibytes". So, for example, a 240 GB drive is reported as `223.6G` by `lsblk`.

In the API, we'd *like* to standardize on raw byte counts, so that we can convert to a human-readable form like SI units (gigabytes, terabytes) or IEC units (gibibytes, tibibytes) without potentially losing accuracy.