### PR TITLE
feat: add serial information gathering for dell and supermicro

### DIFF
--- a/packethardware/component/management_controller.py
+++ b/packethardware/component/management_controller.py
@@ -28,6 +28,10 @@ class ManagementController(Component):
             self.name = self.model + " Base Management Controller"
 
         self.vendor = utils.normalize_vendor(utils.get_mc_info("vendor"))
+
+        if "unknown" in self.vendor.lower():
+            self.vendor = utils.get_hardwarevendor_from_hostnamectl(self)
+
         self.serial = utils.get_mc_info("guid")
 
         self.data = {"aux": utils.get_mc_info("aux")}

--- a/packethardware/component/management_controller.py
+++ b/packethardware/component/management_controller.py
@@ -36,6 +36,26 @@ class ManagementController(Component):
 
         self.data = {"aux": utils.get_mc_info("aux")}
 
+        if "supermicro" in self.vendor.lower():
+            self.data["tty"] = utils.get_supermicro_serial_port_settings(self)
+            self._set_tty_port_guess()
+        elif "dell" in self.vendor.lower():
+            self.data["tty"] = utils.get_dell_bios_serial_comm_settings(self)
+            self._set_tty_port_guess()
+        else:
+            pass
+
+    def _set_tty_port_guess(self):
+        serial_comm = self.data["tty"].get("SerialComm")
+        out_of_band_mgmt_port = (
+            self.data["tty"]
+            .get("Serial Port Console Redirection", {})
+            .get("Out-of-Band Mgmt Port")
+        )
+
+        if serial_comm == "OnConRedirCom1" or out_of_band_mgmt_port == "COM1":
+            self.data["tty"]["ttyPortGuess"] = "ttyS1"
+
     @classmethod
     def list(cls, _):
         bmcs = []

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -546,3 +546,17 @@ def get_bios_features():
     obj = json.loads(bios_features)
 
     return json.dumps(obj)
+
+
+def get_hardwarevendor_from_hostnamectl(self):
+    hostnamectl_output = cmd_output("hostnamectl", "--json", "pretty")
+    if hostnamectl_output:
+        try:
+            data = json.loads(hostnamectl_output)
+            return data.get("HardwareVendor", None)
+        except json.JSONDecodeError:
+            print("Failed to parse JSON output")
+            return None
+    else:
+        print("Failed to get hostnamectl output")
+        return None

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -119,6 +119,25 @@ def get_smart_devices():
     return smart_map
 
 
+def get_dell_bios_serial_comm_settings(self):
+    racadm_output = cmd_output(
+        "/opt/dell/srvadmin/bin/idracadm7", "get", "BIOS.SerialCommSettings"
+    )
+
+    serial_settings = {}
+
+    lines = racadm_output.strip().split("\n")[1:]
+
+    for line in lines:
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        serial_settings[key.strip()] = value.strip()
+
+    return serial_settings
+
+
 def get_nvme_attributes(device):
     smartctl_json = cmd_output("smartctl", "--all", "--json", device)
     return json.loads(smartctl_json)["nvme_smart_health_information_log"]

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -138,6 +138,46 @@ def get_dell_bios_serial_comm_settings(self):
     return serial_settings
 
 
+def get_supermicro_serial_port_settings(self):
+    # cmd_output was giving me UnicodeDecodeError: 'utf-8' so just do our own
+    command = ["/opt/supermicro/sum", "-c", "GetCurrentBiosCfg", "--no_banner"]
+    result = subprocess.run(command, capture_output=True, check=True).stdout
+
+    # get rid of any empty lines at the start
+    result = result.lstrip(b"\n")
+
+    parser = etree.XMLParser(encoding="ISO-8859-1")
+    root = etree.fromstring(result, parser=parser)
+
+    menu_sections = root.xpath(
+        ".//Menu[@name='Serial Port 1 Configuration' or "
+        "@name='Serial Port 2 Configuration' or "
+        "@name='Serial Port Console Redirection']"
+    )
+
+    settings_dict = {}
+
+    for menu_section in menu_sections:
+        menu_name = menu_section.get("name")
+
+        settings = menu_section.findall(".//Setting[@selectedOption]")
+
+        for setting in settings:
+            name = setting.get("name")
+            selected_option = setting.get("selectedOption")
+
+            if selected_option == "Auto":
+                option_value_1 = setting.find(".//Option[@value='1']")
+                if option_value_1 is not None:
+                    selected_option = f"Auto ({option_value_1.text})"
+
+            if menu_name not in settings_dict:
+                settings_dict[menu_name] = {}
+            settings_dict[menu_name][name] = selected_option
+
+    return settings_dict
+
+
 def get_nvme_attributes(device):
     smartctl_json = cmd_output("smartctl", "--all", "--json", device)
     return json.loads(smartctl_json)["nvme_smart_health_information_log"]


### PR DESCRIPTION
Supermicro
```
{
  "aux": "0x09 0x01 0x00 0x00",
  "tty": {
    "Bits per second": "115200",
    "Data Bits": "8",
    "Flow Control": "None",
    "Legacy OS Redirection Resolution": "80x25",
    "Out-of-Band Mgmt Port": "COM1",
    "Parity": "None",
    "Putty KeyPad": "VT100",
    "Redirection After BIOS POST": "Always Enable",
    "Redirection COM Port": "COM1",
    "Stop Bits": "1",
    "Terminal Type": "VT-UTF8"
  }
}
```

Dell
```
{
  "aux": "0x00 0x34 0x00 0x00",
  "tty": {
    "ConTermType": "Vt100Vt220",
    "ExtSerialConnector": "Serial1",
    "FailSafeBaud": "115200",
    "RedirAfterBoot": "Enabled",
    "SerialComm": "OnConRedirCom1",
    "SerialPortAddress": "Serial1Com1Serial2Com2"
  }
}
```