### PR TITLE
utils: even on error, output is useful

### DIFF
--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -74,7 +74,6 @@ def cmd_output(*cmd):
 
     if retcode:
         log(cmd=cmd[0], errorcode=retcode)
-        return ""
 
     return out.decode()
 


### PR DESCRIPTION
This bug has been found when `ipmitool` output was usable, but returned an non-zero error code.