### PR TITLE
FS-1291: Add lsblk version to JSON, in a compatible way

### DIFF
--- a/packethardware/component/disk.py
+++ b/packethardware/component/disk.py
@@ -8,11 +8,13 @@ class Disk(Component):
     @classmethod
     def list(cls, _):
         disks = []
-        for disk in utils.lsblk():
+        jsondisks, tool = utils.lsblk()
+        for disk in jsondisks:
             if not disk["name"].startswith("/dev/sd") and not disk["name"].startswith(
                 "/dev/nvme"
             ):
                 continue
+            disk["tool"] = tool
             disks.append(cls(disk))
         return disks
 

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -88,7 +88,8 @@ def lsblk():
     lsblk_json = cmd_output(
         "lsblk", "-b", "-J", "-p", "-o", "NAME,SERIAL,MODEL,SIZE,REV,ROTA,VENDOR"
     )
-    return json.loads(lsblk_json)["blockdevices"]
+    lsblk_tool = cmd_output("lsblk", "-V").rstrip()
+    return (json.loads(lsblk_json)["blockdevices"], lsblk_tool)
 
 
 def get_smart_devices():


### PR DESCRIPTION
I add the tool to the JSON data of each disks, so that the output of lsblk is still a disks list