### PR TITLE
Ensure lshw output is always listified

### DIFF
--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -296,7 +296,9 @@ def get_megaraid_prop(prop):
 
 def lshw():
     # Workaround for x.large.arm: Skip framebuffer test ("-disable fb")
-    return cmd_output("lshw", "-xml", "-quiet", "-disable", "fb")
+    return cmd_output(
+        "lshw", "-xml", "-quiet", "-disable", "fb", "-enable", "output:list"
+    )
 
 
 def lspci(pci_id):


### PR DESCRIPTION
lshw changed the output of -xml between B.02.19 and B.02.20, in commit 2b1c730b493d647bbab4854713571458e82a81e7 (https://ezix.org/src/pkg/lshw/commit/2b1c730b493d647bbab4854713571458e82a81e7). This commit seems to try to fix the JSON output but in doing so sets `disable("output:list")` in main. This was feature/setting was being used by the code in hwNode::asXML.

It seems that options are default enabled and thus we were getting the xml data listified. When the output:list was disabled in that commit we stopped getting listified xml. I have verified that we can enable the option by passing it in the cli args as `-enable output:list`.