### PR TITLE
Add support for extended Dell version

### DIFF
--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -536,7 +536,7 @@ def get_mc_info(prop):
         # Dell version encoding
         # Their version is A.B.C.D, but we only report A.B.C as D is always 0
         # aux: "0x00 0x1e 0x1e 0x00" -> ".30", not ".30.00"
-        if get_mc_info("vendor") == "DELL Inc":
+        if normalize_vendor(get_mc_info("vendor")) == "Dell Inc.":
             return (
                 __re_multiline_first(mc_info, regex[prop]).strip()
                 + "."

--- a/packethardware/utils.py
+++ b/packethardware/utils.py
@@ -533,6 +533,17 @@ def get_mc_info(prop):
     if prop == "aux":
         return re.sub(r"\s+", " ", __re_multiline_first(mc_info, regex[prop]).strip())
     elif prop == "firmware_version":
+        # Dell version encoding
+        # Their version is A.B.C.D, but we only report A.B.C as D is always 0
+        # aux: "0x00 0x1e 0x1e 0x00" -> ".30", not ".30.00"
+        if get_mc_info("vendor") == "DELL Inc":
+            return (
+                __re_multiline_first(mc_info, regex[prop]).strip()
+                + "."
+                + str(int(get_mc_info("aux")[5:9], 16))
+            )
+
+        # firmware_version provides X.Y, aux 1st byte provides .Z
         # Note that aux byte 0 is patch version in BCD, so 0x11 mean X.Y.11
         return (
             __re_multiline_first(mc_info, regex[prop]).strip()


### PR DESCRIPTION
`firmware_version` provides `X.Y`

To have version as `X.Y.Z`, we need to look at the aux firmware rev info, which has `Z` in the 2nd byte (NOT encoded in BCD).